### PR TITLE
Integrate with file-loader and url-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   },
   "devDependencies": {
     "lqip": "^2.0.2"
+  },
+  "peerDependencies": {
+    "file-loader": "*"
   }
 }


### PR DESCRIPTION
Thank you for your hard work with this amazing loader. I read through the source code and saw the todo comment about moving away from pitch and integrating with file-loader and url-loader. This PR does just that, and would resolve https://github.com/zouhir/lqip-loader/issues/7.

If it is used by itself, it will fall back on the new file-loader peer dependency:

```javascript
{
  test: /\.(png|jpe?g)$/,
  loaders: [
    {
      loader: 'lqip-loader'
      options: {
        base64: true,
        palette: false
      }
    }
  ]
}
```
It can also be used in series:
```javascript
{
  test: /\.(png|jpe?g)$/,
  loaders: [
    {
      loader: 'lqip-loader',
      options: {
        base64: true,
        palette: false
      }
    },
    {
      loader: "url-loader",
      options: {
        limit: 8000
      }
    }
  ]
}
```

This PR is currently using file-loaders value for the public path, `publicPath`, and not `path` like this loader does. If you would like this PR, we could discuss if it should be a change to the API or if I should add support for `path` as well.