### PR TITLE
fix the `err is not defined` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,12 +72,12 @@ module.exports = function(contentBuffer) {
         // the output will be sent to webpack!
         callback(null, result);
       } else {
-        callback(err, null);
+        callback(new Error('No data received'), null);
       }
     })
     .catch(error => {
       console.error(error);
-      callback(err, null);
+      callback(error, null);
     });
 };
 


### PR DESCRIPTION
The application is forced to exit when an error is raised, that's because is being referenced an undefined variable when the callback function is executed.