### PR TITLE
fix: Typo in err passed to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function(contentBuffer) {
     })
     .catch(error => {
       console.error(error);
-      callback(err, null);
+      callback(error, null);
     });
 };
 


### PR DESCRIPTION
Caught error is improperly renamed. This breaks TypeScript builds for
missing file imports using `?lqip`. JS builds fine so it's easy to miss.

Sample affected project [cyrilwanner/next-optimized-images/issues/162](https://github.com/cyrilwanner/next-optimized-images/issues/162).